### PR TITLE
refactor: adiciona alias para globalStyles

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'; 
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@globalStyles': path.resolve(__dirname, './src/globalStyles'),
+    },
+  },
 })


### PR DESCRIPTION
Criado um alias '@globalStyles' que aponta para o diretório './src/globalStyles' para simplificar importações.

uso: import '@globalStyles/NomeDoArquivo.css'